### PR TITLE
Unclogging pipes

### DIFF
--- a/config.py
+++ b/config.py
@@ -111,7 +111,7 @@ def _xrd_locate(redirs, file_name, max_age):
 
                 proc.communicate()
 
-def get_redirector(site, banned_doors=[]):
+def get_redirector(site, banned_doors=None):
     """
     Get the redirector and xrootd door servers for a given site.
     An example valid site name is ``T2_US_MIT``.
@@ -123,6 +123,8 @@ def get_redirector(site, banned_doors=[]):
               and a list of xrootd door servers
     :rtype: str, list
     """
+    banned_doors = banned_doors or []
+
     LOG.debug('Getting doors for %s', site)
     config = config_dict()
     max_age = config.get('RedirectorAge', 0) * 24 * 3600

--- a/config.py
+++ b/config.py
@@ -67,8 +67,8 @@ def config_dict():
     num_threads = os.environ.get('NumThreads', output.get('NumThreads'))
     # If NumThreads is non zero or not none
     if num_threads:
-        output['MaxThreads'] = num_threads
-        output['MinThreads'] = num_threads
+        output['MaxThreads'] = int(num_threads)
+        output['MinThreads'] = int(num_threads)
 
     cache_location = output.get('CacheLocation')
 

--- a/config.py
+++ b/config.py
@@ -111,13 +111,14 @@ def _xrd_locate(redirs, file_name, max_age):
 
                 proc.communicate()
 
-
-def get_redirector(site):
+def get_redirector(site, banned_doors=[]):
     """
     Get the redirector and xrootd door servers for a given site.
     An example valid site name is ``T2_US_MIT``.
 
     :param str site: The site we want to contact
+    :param list banned_doors: Give a list of doors to not return.
+                              These are usually ones that just timed out.
     :returns: Public hostname of the local redirector
               and a list of xrootd door servers
     :rtype: str, list
@@ -156,7 +157,8 @@ def get_redirector(site):
 
     # Get the list of doors
     with open(list_name, 'r') as list_file:
-        local_list = list(set([line.strip() for line in list_file]))
+        local_list = list(set([line.strip() for line in list_file \
+                                   if line.strip() not in banned_doors]))
 
     LOG.debug('From %s, got list %s', redirector, local_list)
 

--- a/datatypes.py
+++ b/datatypes.py
@@ -86,6 +86,7 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
 
     master_conns = []
     slave_conns = []
+    send_to_master = []
 
     for _ in xrange(n_threads):
         in_queues.append(multiprocessing.Queue())
@@ -93,6 +94,7 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
         con1, con2 = multiprocessing.Pipe()
         master_conns.append(con1)
         slave_conns.append(con2)
+        send_to_master.append(multiprocessing.Queue())
 
     # Put in the first element for the queues
     # They go like, (full path of the next listing to do,
@@ -117,6 +119,8 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
         # Get the queue and connection for this thread
         in_queue = in_queues[i_queue]
         conn = slave_conns[i_queue]
+
+        done_count = 0
 
         if object_params:
             # Create the object with the parameters here
@@ -191,15 +195,20 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
                             put((location, joined_name, [], [], []))
 
 
-                # Tell master that a job finished, so it can build the final object
-                conn.send('One_Job')
-                conn.send(time.time())
+                # Tell master that a job finished once in a while,
+                # so it can build the final object
+                send_to_master[i_queue].put(('O', time.time()))
+                #done_count += 1
+                #if done_count % 5 == 0:
+                #    conn.send('O')
+                #    conn.send(time.time())
 
                 thread_log.debug('Finished one job with (%s, %s)', location, name)
             except Empty:
                 # Report empty
-                thread_log.info('Worker finished input queue')
-                conn.send('All_Job')
+                thread_log.debug('Worker finished input queue')
+                send_to_master[i_queue].put(('A', 0))
+                #conn.send('All_Job')
 
                 # Check for main process
                 message = conn.recv()
@@ -209,7 +218,7 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
                     conn.close()
                     running = False
                 else:
-                    thread_log.info('Worker going back to check queue')
+                    thread_log.debug('Worker going back to check queue')
 
     # Spawn processes to run on this run_queue function
     processes = []
@@ -246,15 +255,16 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
             threads_done = 0
             for conn in master_conns:
                 LOG.debug('Waiting for thread %i', master_conns.index(conn))
-                message = conn.recv()
+                message, timestamp = send_to_master[master_conns.index(conn)].get(True)
+
                 LOG.debug('Recieved message %s', message)
                 # Count the number of threads saying their finished at the beginning
-                if message == 'All_Job':
+                if message == 'A':
                     threads_done += 1
-                    LOG.debug('Threads saying done: %i', threads_done)
+                    LOG.info('Threads saying done: %i', threads_done)
                     # Send back to work, just in case not all threads are done
                     conn.send('Work')
-                elif message == 'One_Job':
+                elif message == 'O':
                     # This thread wasn't finished at the beginning, so threads_done
                     # will not reach n_threads if the master reaches this point in the code
                     LOG.debug('Found one job, about to cycle')
@@ -262,17 +272,17 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
                     cycle = True
                     while cycle:
                         # Cycle through timestamps so that we do not have a backlog
-                        timestamp = conn.recv()
-                        # Wait for a new job to finish
-                        if now - timestamp < 0.0:
-                            LOG.debug('Found new message, breaking.')
-                            cycle = False
-                        else:
-                            mess = conn.recv()
-                            if mess == 'All_Job':
+                        try:
+                            message, timestamp = send_to_master[master_conns.index(conn)].get(True, 1)
+                            if message == 'A':
                                 LOG.debug('Found end to pipe.')
                                 conn.send('Work')
                                 cycle = False
+                            elif timestamp > now:
+                                cycle = False
+                        except Empty:
+                            cycle = False
+
                 else:
                     LOG.error('Weird message from pipe')
 
@@ -293,7 +303,7 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
     for proc in processes:
         proc.join()
 
-    dir_info.setup_hash()
+    #dir_info.setup_hash()
     return dir_info
 
 

--- a/datatypes.py
+++ b/datatypes.py
@@ -120,8 +120,6 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
         in_queue = in_queues[i_queue]
         conn = slave_conns[i_queue]
 
-        done_count = 0
-
         if object_params:
             # Create the object with the parameters here
             params = object_params[i_queue]
@@ -198,10 +196,6 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
                 # Tell master that a job finished once in a while,
                 # so it can build the final object
                 send_to_master[i_queue].put(('O', time.time()))
-                #done_count += 1
-                #if done_count % 5 == 0:
-                #    conn.send('O')
-                #    conn.send(time.time())
 
                 thread_log.debug('Finished one job with (%s, %s)', location, name)
             except Empty:
@@ -273,7 +267,8 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
                     while cycle:
                         # Cycle through timestamps so that we do not have a backlog
                         try:
-                            message, timestamp = send_to_master[master_conns.index(conn)].get(True, 1)
+                            message, timestamp = \
+                                send_to_master[master_conns.index(conn)].get(True, 1)
                             if message == 'A':
                                 LOG.debug('Found end to pipe.')
                                 conn.send('Work')

--- a/getsitecontents.py
+++ b/getsitecontents.py
@@ -43,6 +43,7 @@ class XRootDLister(object):
         :param str primary_door: The URL of the door that will get the most load
         :param str backup_door: The URL of the door that will be used when
                                 the primary door fails
+        :param str site: The site that this connection is to.
         :param int thread_num: This optional parameter is only used to
                                Create a separate logger for this object
         :param bool do_both: If true, the primary and backup doors will both
@@ -53,6 +54,7 @@ class XRootDLister(object):
         self.backup_conn = XRootD.client.FileSystem(backup_door)
         self.do_both = do_both
         self.tries = config.config_dict().get('Retries', 0) + 1
+        self.site = site
 
         # This regex is used to parse the error code and propose a retry
         self.error_re = re.compile(r'\[(\!|\d+|FATAL)\]')
@@ -160,7 +162,8 @@ class XRootDLister(object):
             self.log.warning('Directory %s timed out.', path)
 
             # Reconnect
-            _, door_list = get_redirector(self.site, [self.primary_conn.url, self.backup_conn.url])
+            _, door_list = config.get_redirector(self.site,
+                                                 [self.primary_conn.url, self.backup_conn.url])
             use_doors = random.sample(door_list, 2)
 
             if use_doors:

--- a/test/T2/compare.py
+++ b/test/T2/compare.py
@@ -3,11 +3,48 @@
 import logging
 import sys
 import os
+import sqlite3
+import shutil
+import time
 
 from ConsistencyCheck import getsitecontents
 from ConsistencyCheck import getinventorycontents
 from ConsistencyCheck import datatypes
 from ConsistencyCheck import config
+
+
+def main(site):
+    start = time.time()
+
+    site_tree = getsitecontents.get_site_tree(site)
+
+    webdir = '/home/dabercro/public_html/ConsistencyCheck'
+
+    try:
+        inv_tree = getinventorycontents.get_site_inventory(site)
+
+        missing, orphan = datatypes.compare(inv_tree, site_tree, '%s_compare' % site)
+
+
+        shutil.copy('%s_compare_missing.txt', webdir)
+        shutil.copy('%s_compare_orphan.txt', webdir)
+    except:
+        missing = []
+        orphan = []
+
+
+    conn = sqlite3.connect(os.path.join(webdir, 'stats.db'))
+    curs = conn.cursor()
+
+    curs.execute('REPLACE INTO stats VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+                 (site, time.time() - start, site_tree.get_num_files(),
+                  site_tree.count_nodes(), site_tree.count_nodes(True),
+                  config.config_dict().get('NumThreads', config.config_dict().get('MinThreads', 0)),
+                  len(missing), len(orphan)))
+
+    conn.commit()
+    conn.close()
+
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:
@@ -23,7 +60,4 @@ if __name__ == '__main__':
         logging.basicConfig(level=logging.INFO,
                             format='%(asctime)s:%(levelname)s:%(name)s: %(message)s')
 
-    site_tree = getsitecontents.get_site_tree(site)
-    inv_tree = getinventorycontents.get_site_inventory(site)
-
-    datatypes.compare(inv_tree, site_tree, '%s_compare' % site)
+    main(site)

--- a/test/T2/consistency_config.json
+++ b/test/T2/consistency_config.json
@@ -1,6 +1,6 @@
 {
-  "Timeout": 90,
-  "Retries": 3,
+  "Timeout": 10,
+  "Retries": 0,
   "InventoryAge": 5e-05,
   "MinThreads": 8,
   "MaxThreads": 8,

--- a/test/T2/list.py
+++ b/test/T2/list.py
@@ -1,0 +1,26 @@
+#! /usr/bin/env python
+
+import logging
+
+from compare import main
+
+if __name__ == '__main__':
+
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(asctime)s:%(levelname)s:%(name)s: %(message)s')
+
+    sites = [
+#        'T3_US_MIT',
+        'T2_US_MIT',
+#        'T2_US_Nebraska',
+#        'T2_US_Florida',
+#        'T2_US_Purdue',
+#        'T2_US_UCSD',
+        'T2_US_Vanderbilt',
+        'T1_US_FNAL',
+#        'T2_US_Wisconsin',
+#        'T2_US_Caltech',
+        ]
+
+    for site in sites:
+        main(site)


### PR DESCRIPTION
Uses a queue instead of pipes to tell the master process when to go back and check. This prevents threads from blocking while the master is waiting around for another thread.